### PR TITLE
Code adjustments for Decidim Omniauth integration

### DIFF
--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -53,17 +53,19 @@ class SecurityController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $data = $form->getData();
+
             switch (true) {
-                case $form->get('accept') == "on":
+                case $data["accept"]:
                     $request->getSession()->set(AuthorizationRequestResolverSubscriber::SESSION_AUTHORIZATION_RESULT, true);
                     break;
-                case $form->get('refuse') == "on":
+                case $data["refuse"]:
                     $request->getSession()->set(AuthorizationRequestResolverSubscriber::SESSION_AUTHORIZATION_RESULT, false);
                     break;
             }
 
-            return $this->redirect($request->getSchemeAndHttpHost() . "/authorize");
-//            return $this->redirectToRoute('oauth2_authorize', $request->query->all());
+//            return $this->redirect($request->getSchemeAndHttpHost() . "/authorize");
+            return $this->redirectToRoute('oauth2_authorize', $request->query->all());
         }
 
         return $this->render('oauth2/authorization.html.twig', [


### PR DESCRIPTION
This PR treats the case when the consent checkboxes are being filled in. 

Submitting the consent form leads to a "invalid_client" error, as the authorize method cannot properly identify the requested grant. 

Fixing the redirect, revealead another issue in which, submitting the consent form, would post the data to `consent` method, then redirect to authorize screen. The `authorize` screen would check if  `AuthorizationRequestResolverSubscriber::SESSION_AUTHORIZATION_RESULT` is being set or not, and if not would redirect to the consent. 

Refs: https://github.com/Platoniq/decidim-module-goteo_oauth/pull/2