### PR TITLE
[FEAT] Update Auth token TTL

### DIFF
--- a/.env
+++ b/.env
@@ -34,4 +34,5 @@ OAUTH_PRIVATE_KEY=%kernel.project_dir%/config/jwt/private.pem
 OAUTH_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 OAUTH_PASSPHRASE=5350dadf2987e9830cb8cf24114577fe
 OAUTH_ENCRYPTION_KEY=80c1a79c6c22c87711fde0b515de0c06
+OAUTH_ACCESS_TOKEN_TTL=P1D
 ###< league/oauth2-server-bundle ###

--- a/config/packages/league_oauth2_server.yaml
+++ b/config/packages/league_oauth2_server.yaml
@@ -3,6 +3,7 @@ league_oauth2_server:
         private_key: '%env(resolve:OAUTH_PRIVATE_KEY)%'
         private_key_passphrase: '%env(resolve:OAUTH_PASSPHRASE)%'
         encryption_key: '%env(resolve:OAUTH_ENCRYPTION_KEY)%'
+        access_token_ttl: '%env(resolve:OAUTH_ACCESS_TOKEN_TTL)%'
     resource_server:
         public_key: '%env(resolve:OAUTH_PUBLIC_KEY)%'
     scopes:


### PR DESCRIPTION
This PR allows to set the TTL of the generated access token via en env var. The default has been updated to be a 1 day period. 