### PR TITLE
[fix] logout locale route collision

### DIFF
--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -45,7 +45,7 @@ class SecurityController extends AbstractController
         return $this->render('security/login.html.twig', ['last_username' => $lastUsername, 'error' => $error]);
     }
 
-    #[Route('/logout', name: 'app_logout')]
+    #[Route('/{_locale}/logout', name: 'app_logout')]
     public function logout(): void
     {
         throw new LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');


### PR DESCRIPTION
It was not possible to perform a logout due to the router trying to resolve `logout` to a locale. Added the `{_locale}` path var to avoid route collision.